### PR TITLE
Fix build errors on kernel 6.12.10-arch1-1:

### DIFF
--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -645,7 +645,7 @@ error:
 	return rc;
 }
 
-static int appleals_platform_remove(struct platform_device *pdev)
+static void appleals_platform_remove(struct platform_device *pdev)
 {
 	struct appleib_device_data *ddata = pdev->dev.platform_data;
 	struct appleib_device *ib_dev = ddata->ib_dev;
@@ -658,10 +658,10 @@ static int appleals_platform_remove(struct platform_device *pdev)
 
 	kfree(als_dev);
 
-	return 0;
+	return;
 
 error:
-	return rc;
+	return;
 }
 
 static const struct platform_device_id appleals_platform_ids[] = {

--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -1259,7 +1259,7 @@ error:
 	return rc;
 }
 
-static int appletb_platform_remove(struct platform_device *pdev)
+static void appletb_platform_remove(struct platform_device *pdev)
 {
 	struct appleib_device_data *ddata = pdev->dev.platform_data;
 	struct appleib_device *ib_dev = ddata->ib_dev;
@@ -1272,10 +1272,10 @@ static int appletb_platform_remove(struct platform_device *pdev)
 
 	appletb_free_device(tb_dev);
 
-	return 0;
+	return;
 
 error:
-	return rc;
+	return;
 }
 
 static const struct platform_device_id appletb_platform_ids[] = {

--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -422,7 +422,7 @@ static int appleib_hid_event(struct hid_device *hdev, struct hid_field *field,
 	return appleib_forward_int_op(hdev, appleib_hid_event_fwd, &args);
 }
 
-static __u8 *appleib_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+static const __u8 *appleib_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 				  unsigned int *rsize)
 {
 	/* Some fields have a size of 64 bits, which according to HID 1.11
@@ -898,7 +898,7 @@ MODULE_DEVICE_TABLE(acpi, appleib_acpi_match);
 static struct acpi_driver appleib_driver = {
 	.name		= "apple-ibridge",
 	.class		= "topcase", /* ? */
-	.owner		= THIS_MODULE,
+	//.owner		= THIS_MODULE,
 	.ids		= appleib_acpi_match,
 	.ops		= {
 		.add		= appleib_probe,


### PR DESCRIPTION
update remove callbacks, adjusted report fixup return type, and remove deprecated owner field

I'm hoping this will help anyone trying to get it to build via dkms install on a 6.12+ kernel.  Still having issues with my touchbar responding but it's the first time I've been able to get it to build and install successfully so I believe I'm on the right track.